### PR TITLE
Removing extra cache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
       uses: actions/setup-java@v3
       with:
         java-version: '11'
-        distribution: 'temurin'
+        distribution: 'liberica'
         cache: gradle
         
     - name: 🙌 Copy secrets file
@@ -30,15 +30,6 @@ jobs:
 
     - name: 📝 Grant execute permission for gradlew
       run: chmod +x gradlew
-      
-    - uses: actions/cache@v2
-      with:
-        path: |
-            ~/.gradle/caches
-            ~/.gradle/wrapper
-        key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
-        restore-keys: |
-            ${{ runner.os }}-gradle-
       
     - name: 👷‍♀️ Build with Gradle
       run: ./gradlew build


### PR DESCRIPTION
The `setup-java` action has support for caching gradle as well. So no need to double up